### PR TITLE
Upgrade Effect to beta.70 and rename Model.Generated to GeneratedByDb

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -90,7 +90,7 @@ import { Model } from 'effect/unstable/schema';
 import { Firestore } from 'effect-firebase';
 
 class AuthorModel extends Model.Class<AuthorModel>('AuthorModel')({
-  id: Model.Generated(AuthorId), // generic helpers from Effect's Model
+  id: Model.GeneratedByDb(AuthorId), // generic helpers from Effect's Model
   createdAt: Firestore.DateTimeInsert, // Firestore-specific helpers from effect-firebase
   updatedAt: Firestore.DateTimeUpdate,
   author: Firestore.Reference(AuthorId, 'authors'),
@@ -110,7 +110,7 @@ Generic field helpers that no longer need the `effect-firebase` import:
 | Field helper           | Now from                 |
 | ---------------------- | ------------------------ |
 | `Model.Class`          | `effect/unstable/schema` |
-| `Model.Generated`      | `effect/unstable/schema` |
+| `Model.GeneratedByDb`  | `effect/unstable/schema` |
 | `Model.GeneratedByApp` | `effect/unstable/schema` |
 | `Model.Sensitive`      | `effect/unstable/schema` |
 | `Model.FieldOption`    | `effect/unstable/schema` |

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ const PostId = Schema.String.pipe(Schema.brand('PostId'));
 const AuthorId = Schema.String.pipe(Schema.brand('AuthorId'));
 
 class PostModel extends Model.Class<PostModel>('PostModel')({
-  id: Model.Generated(PostId),
+  id: Model.GeneratedByDb(PostId),
   createdAt: Model.DateTimeInsert,
   updatedAt: Model.DateTimeUpdate,
   author: Model.Reference(AuthorId, 'authors'),

--- a/example/app/package.json
+++ b/example/app/package.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "effect": "^4.0.0-beta.43",
-    "@effect/platform-browser": "^4.0.0-beta.43",
+    "effect": "^4.0.0-beta.70",
+    "@effect/platform-browser": "^4.0.0-beta.70",
     "firebase": "^12.8.0",
     "tailwind-merge": "^3.4.0",
     "react": "19.2.4",

--- a/example/backend/package.json
+++ b/example/backend/package.json
@@ -12,7 +12,7 @@
   },
   "packageManager": "pnpm@10.25.0",
   "dependencies": {
-    "effect": "^4.0.0-beta.43",
+    "effect": "^4.0.0-beta.70",
     "firebase-admin": "^13.6.0",
     "@google-cloud/functions-framework": "^5.0.0",
     "@effect-firebase/admin": "workspace:*",

--- a/example/shared/package.json
+++ b/example/shared/package.json
@@ -20,7 +20,7 @@
     "!**/*.tsbuildinfo"
   ],
   "dependencies": {
-    "effect": "^4.0.0-beta.43",
+    "effect": "^4.0.0-beta.70",
     "tslib": "^2.3.0"
   },
   "peerDependencies": {

--- a/example/shared/src/models/author.ts
+++ b/example/shared/src/models/author.ts
@@ -6,7 +6,7 @@ export const AuthorId = Schema.String.pipe(Schema.brand('AuthorId'));
 export const AuthorRef = Firestore.Reference(AuthorId, 'authors');
 
 export class AuthorModel extends Model.Class<AuthorModel>('AuthorModel')({
-  id: Model.Generated(AuthorId),
+  id: Model.GeneratedByDb(AuthorId),
   createdAt: Firestore.DateTimeInsert,
   updatedAt: Firestore.DateTimeUpdate,
   name: Schema.String,

--- a/example/shared/src/models/post.ts
+++ b/example/shared/src/models/post.ts
@@ -7,7 +7,7 @@ export const PostId = Schema.String.pipe(Schema.brand('PostId'));
 export const PostRef = Firestore.Reference(PostId, 'posts');
 
 export class PostModel extends Model.Class<PostModel>('PostModel')({
-  id: Model.Generated(PostId),
+  id: Model.GeneratedByDb(PostId),
   createdAt: Firestore.DateTimeInsert,
   updatedAt: Firestore.DateTimeUpdate,
   author: AuthorRef,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "private": true,
   "dependencies": {
     "@google-cloud/functions-framework": "^5.0.2",
-    "effect": "^4.0.0-beta.43",
+    "effect": "^4.0.0-beta.70",
     "firebase": "^12.10.0",
     "firebase-admin": "^13.7.0",
     "firebase-functions": "^7.1.0",
@@ -25,8 +25,8 @@
     "react-dom": "19.2.4"
   },
   "devDependencies": {
-    "@effect/platform-browser": "^4.0.0-beta.43",
-    "@effect/vitest": "^4.0.0-beta.43",
+    "@effect/platform-browser": "^4.0.0-beta.70",
+    "@effect/vitest": "^4.0.0-beta.70",
     "@eslint/js": "^9.8.0",
     "@nx/esbuild": "22.5.4",
     "@nx/eslint": "22.5.4",

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -29,7 +29,7 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "effect": "^4.0.0-beta.43",
+    "effect": "^4.0.0-beta.70",
     "effect-firebase": "workspace:*",
     "firebase": "^12.10.0",
     "firebase-admin": "^13.7.0",
@@ -37,7 +37,7 @@
     "express": "4.21.2"
   },
   "peerDependencies": {
-    "effect": "^4.0.0-beta.43",
+    "effect": "^4.0.0-beta.70",
     "effect-firebase": "workspace:*",
     "firebase-admin": "^13.0.0",
     "firebase-functions": "^7.0.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -29,12 +29,12 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "effect": "^4.0.0-beta.43",
+    "effect": "^4.0.0-beta.70",
     "effect-firebase": "workspace:*",
     "firebase": "^12.9.0"
   },
   "peerDependencies": {
-    "effect": "^4.0.0-beta.43",
+    "effect": "^4.0.0-beta.70",
     "effect-firebase": "workspace:*",
     "firebase": "^12.0.0"
   },

--- a/packages/effect-firebase/README.md
+++ b/packages/effect-firebase/README.md
@@ -22,7 +22,7 @@ import { Model } from 'effect-firebase';
 const PostId = Schema.String.pipe(Schema.brand('PostId'));
 
 class PostModel extends Model.Class<PostModel>('PostModel')({
-  id: Model.Generated(PostId), // excluded from add, required in update
+  id: Model.GeneratedByDb(PostId), // excluded from add and update
   createdAt: Model.DateTimeInsert, // set on create, excluded from update
   updatedAt: Model.DateTimeUpdate, // set on every write
   author: Model.Reference(AuthorId, 'authors'), // stored as DocumentReference
@@ -36,7 +36,7 @@ Built-in field helpers:
 
 | Helper                                      | Behaviour                                                             |
 | ------------------------------------------- | --------------------------------------------------------------------- |
-| `Model.Generated(schema)`                   | Auto-generated (e.g. IDs). Excluded from `add`, required in `update`. |
+| `Model.GeneratedByDb(schema)`               | Auto-generated (e.g. IDs). Excluded from `add` and `update`.          |
 | `Model.DateTimeInsert`                      | Server timestamp on create. Excluded from `update`.                   |
 | `Model.DateTimeUpdate`                      | Server timestamp on every write.                                      |
 | `Model.Reference(id, collection)`           | Branded ID in app, `DocumentReference` in Firestore.                  |

--- a/packages/effect-firebase/package.json
+++ b/packages/effect-firebase/package.json
@@ -29,10 +29,10 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "effect": "^4.0.0-beta.43"
+    "effect": "^4.0.0-beta.70"
   },
   "peerDependencies": {
-    "effect": "^4.0.0-beta.43"
+    "effect": "^4.0.0-beta.70"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/effect-firebase/src/lib/firestore/model/datetime.spec.ts
+++ b/packages/effect-firebase/src/lib/firestore/model/datetime.spec.ts
@@ -9,7 +9,7 @@ describe('Model.DateTime', () => {
   const PostId = Schema.String.pipe(Schema.brand('PostId'));
 
   class TestModel extends Model.Class<TestModel>('TestModel')({
-    id: Model.Generated(PostId),
+    id: Model.GeneratedByDb(PostId),
     createdAt: DateTime,
   }) {}
 
@@ -81,7 +81,7 @@ describe('Model.DateTime', () => {
       const encode = Schema.encodeSync(TestModel.json);
       const dt = EffectDateTime.makeUnsafe(1705315800123);
       const result = encode({
-        id: 'post-1',
+        id: PostId.make('post-1'),
         createdAt: dt,
       });
 
@@ -95,7 +95,7 @@ describe('Model.DateTimeInsert', () => {
   const PostId = Schema.String.pipe(Schema.brand('PostId'));
 
   class TestModel extends Model.Class<TestModel>('TestModel')({
-    id: Model.Generated(PostId),
+    id: Model.GeneratedByDb(PostId),
     createdAt: DateTimeInsert,
   }) {}
 
@@ -157,7 +157,7 @@ describe('Model.DateTimeUpdate', () => {
   const PostId = Schema.String.pipe(Schema.brand('PostId'));
 
   class TestModel extends Model.Class<TestModel>('TestModel')({
-    id: Model.Generated(PostId),
+    id: Model.GeneratedByDb(PostId),
     updatedAt: DateTimeUpdate,
   }) {}
 
@@ -189,7 +189,6 @@ describe('Model.DateTimeUpdate', () => {
     it('should include updatedAt field', () => {
       const decode = Schema.decodeUnknownSync(TestModel.update);
       const result = decode({
-        id: 'post-1',
         updatedAt: Timestamp.fromMillis(1705315800000),
       });
 
@@ -199,7 +198,6 @@ describe('Model.DateTimeUpdate', () => {
     it('should encode undefined to ServerTimestamp', () => {
       const encode = Schema.encodeSync(TestModel.update);
       const result = encode({
-        id: 'post-1' as typeof PostId.Type,
         updatedAt: undefined,
       });
 

--- a/packages/effect-firebase/src/lib/firestore/model/reference.spec.ts
+++ b/packages/effect-firebase/src/lib/firestore/model/reference.spec.ts
@@ -15,7 +15,7 @@ describe('Model.AnyIdReference', () => {
   const PostId = Schema.String.pipe(Schema.brand('PostId'));
 
   class TestModel extends Model.Class<TestModel>('TestModel')({
-    id: Model.Generated(PostId),
+    id: Model.GeneratedByDb(PostId),
     authorId: AnyIdReference,
   }) {}
 
@@ -75,7 +75,7 @@ describe('Model.AnyPathReference', () => {
   const PostId = Schema.String.pipe(Schema.brand('PostId'));
 
   class TestModel extends Model.Class<TestModel>('TestModel')({
-    id: Model.Generated(PostId),
+    id: Model.GeneratedByDb(PostId),
     authorPath: AnyPathReference,
   }) {}
 
@@ -135,7 +135,7 @@ describe('Model.Reference', () => {
   const AuthorId = Schema.String.pipe(Schema.brand('AuthorId'));
 
   class TestModel extends Model.Class<TestModel>('TestModel')({
-    id: Model.Generated(PostId),
+    id: Model.GeneratedByDb(PostId),
     author: Reference(AuthorId, 'authors'),
   }) {}
 
@@ -173,7 +173,6 @@ describe('Model.Reference', () => {
       const encode = Schema.encodeSync(TestModel.update);
       const authorId = 'author-456' as typeof AuthorId.Type;
       const result = encode({
-        id: 'post-1' as typeof PostId.Type,
         author: authorId,
       });
 
@@ -210,7 +209,7 @@ describe('Model.Reference', () => {
     const CommentId = Schema.String.pipe(Schema.brand('CommentId'));
 
     class CommentModel extends Model.Class<CommentModel>('CommentModel')({
-      id: Model.Generated(CommentId),
+      id: Model.GeneratedByDb(CommentId),
       replyTo: Reference(CommentId, 'posts/post-1/comments'),
     }) {}
 
@@ -233,7 +232,7 @@ describe('Model.ReferenceAsInstance', () => {
   const AuthorId = Schema.String.pipe(Schema.brand('AuthorId'));
 
   class TestModel extends Model.Class<TestModel>('TestModel')({
-    id: Model.Generated(PostId),
+    id: Model.GeneratedByDb(PostId),
     author: ReferenceAsInstance(AuthorId, 'authors'),
   }) {}
 
@@ -280,7 +279,6 @@ describe('Model.ReferenceAsInstance', () => {
         path: 'authors/author-456',
       });
       const result = encode({
-        id: 'post-1' as typeof PostId.Type,
         author: authorRef,
       });
 
@@ -340,7 +338,7 @@ describe('Model.ReferencePath', () => {
   const PostId = Schema.String.pipe(Schema.brand('PostId'));
 
   class TestModel extends Model.Class<TestModel>('TestModel')({
-    id: Model.Generated(PostId),
+    id: Model.GeneratedByDb(PostId),
     authorPath: ReferencePath('authors'),
   }) {}
 
@@ -411,7 +409,7 @@ describe('Model.ReferenceOptional', () => {
   const AuthorId = Schema.String.pipe(Schema.brand('AuthorId'));
 
   class TestModel extends Model.Class<TestModel>('TestModel')({
-    id: Model.Generated(PostId),
+    id: Model.GeneratedByDb(PostId),
     author: ReferenceOptional(AuthorId, 'authors'),
   }) {}
 

--- a/packages/effect-firebase/src/lib/firestore/model/reference.ts
+++ b/packages/effect-firebase/src/lib/firestore/model/reference.ts
@@ -67,7 +67,7 @@ export const AnyPathReference = Model.Field({
  * const AuthorId = Schema.String.pipe(Schema.brand('AuthorId'));
  *
  * class PostModel extends Model.Class<PostModel>('PostModel')({
- *   id: Model.Generated(PostId),
+ *   id: Model.GeneratedByDb(PostId),
  *   // App gets AuthorId, DB stores DocumentReference
  *   author: Model.Reference(AuthorId, 'authors'),
  * }) {}
@@ -107,7 +107,7 @@ export const Reference = <Id extends StringBasedSchema>(
  * const AuthorId = Schema.String.pipe(Schema.brand('AuthorId'));
  *
  * class PostModel extends Model.Class<PostModel>('PostModel')({
- *   id: Model.Generated(PostId),
+ *   id: Model.GeneratedByDb(PostId),
  *   // App gets DocumentReference, JSON is AuthorId
  *   author: Model.ReferenceAsInstance(AuthorId, 'authors'),
  * }) {}
@@ -162,7 +162,7 @@ export const ReferenceAsInstance = <Id extends StringBasedSchema>(
  * import { Model } from 'effect-firebase';
  *
  * class PostModel extends Model.Class<PostModel>('PostModel')({
- *   id: Model.Generated(PostId),
+ *   id: Model.GeneratedByDb(PostId),
  *   // Reference - JSON will be the full path string
  *   authorPath: Model.ReferencePath('authors'),
  * }) {}

--- a/packages/effect-firebase/src/lib/firestore/model/repository.spec.ts
+++ b/packages/effect-firebase/src/lib/firestore/model/repository.spec.ts
@@ -9,7 +9,7 @@ import type { Snapshot } from '../snapshot.js';
 const PostId = Schema.String.pipe(Schema.brand('PostId'));
 
 class PostModel extends Model.Class<PostModel>('PostModel')({
-  id: Model.Generated(PostId),
+  id: Model.GeneratedByDb(PostId),
   title: Schema.String,
 }) {}
 

--- a/packages/effect-firebase/src/lib/firestore/model/repository.ts
+++ b/packages/effect-firebase/src/lib/firestore/model/repository.ts
@@ -19,7 +19,7 @@ export type RepositoryQuery<S> = ReadonlyArray<QueryConstraint> & {
 
 export type Repository<
   S extends Model.Any,
-  Id extends keyof S['Type'] & keyof S['update']['Type'] & keyof S['fields'],
+  Id extends keyof S['Type'] & keyof S['fields'],
   IdSchema extends S['fields'][Id] extends Schema.String
     ? S['fields'][Id]
     : never
@@ -203,7 +203,7 @@ export type Repository<
  */
 export const makeRepository = <
   S extends Model.Any,
-  Id extends keyof S['Type'] & keyof S['update']['Type'] & keyof S['fields'],
+  Id extends keyof S['Type'] & keyof S['fields'],
   IdSchema extends S['fields'][Id] extends Schema.String
     ? S['fields'][Id]
     : never

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -30,11 +30,11 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "effect": "^4.0.0-beta.43",
+    "effect": "^4.0.0-beta.70",
     "effect-firebase": "workspace:*"
   },
   "peerDependencies": {
-    "effect": "^4.0.0-beta.43",
+    "effect": "^4.0.0-beta.70",
     "effect-firebase": "workspace:*"
   },
   "publishConfig": {

--- a/packages/mock/src/lib/firestore/firestore-service.ts
+++ b/packages/mock/src/lib/firestore/firestore-service.ts
@@ -28,9 +28,6 @@ export const MockFirestoreService = (
     deleteRecursive: () => {
       throw new Error('MockFirestoreService.deleteRecursive not implemented.');
     },
-    deleteRecursive: () => {
-      throw new Error('MockFirestoreService.deleteRecursive not implemented.');
-    },
     query: () => {
       throw new Error('MockFirestoreService.query not implemented.');
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^5.0.2
         version: 5.0.2
       effect:
-        specifier: ^4.0.0-beta.43
-        version: 4.0.0-beta.46
+        specifier: ^4.0.0-beta.70
+        version: 4.0.0-beta.70
       firebase:
         specifier: ^12.10.0
         version: 12.10.0
@@ -31,11 +31,11 @@ importers:
         version: 19.2.4(react@19.2.4)
     devDependencies:
       '@effect/platform-browser':
-        specifier: ^4.0.0-beta.43
-        version: 4.0.0-beta.46(effect@4.0.0-beta.46)
+        specifier: ^4.0.0-beta.70
+        version: 4.0.0-beta.70(effect@4.0.0-beta.70)
       '@effect/vitest':
-        specifier: ^4.0.0-beta.43
-        version: 4.0.0-beta.46(effect@4.0.0-beta.46)(vitest@4.0.9)
+        specifier: ^4.0.0-beta.70
+        version: 4.0.0-beta.70(effect@4.0.0-beta.70)(vitest@4.0.9)
       '@eslint/js':
         specifier: ^9.8.0
         version: 9.28.0
@@ -53,13 +53,13 @@ importers:
         version: 22.5.4(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))
       '@nx/react':
         specifier: 22.5.4
-        version: 22.5.4(@babel/core@7.28.0)(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/helpers@0.5.19)(@types/babel__core@7.20.5)(@zkochan/js-yaml@0.0.7)(esbuild@0.19.12)(eslint@9.28.0(jiti@2.4.2))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.0.9)
+        version: 22.5.4(@babel/core@7.28.0)(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/helpers@0.5.19)(@types/babel__core@7.20.5)(@zkochan/js-yaml@0.0.7)(esbuild@0.19.12)(eslint@9.28.0(jiti@2.4.2))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0))(vitest@4.0.9)
       '@nx/vite':
         specifier: 22.5.4
-        version: 22.5.4(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(typescript@5.9.3)(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.0.9)
+        version: 22.5.4(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(typescript@5.9.3)(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0))(vitest@4.0.9)
       '@nx/vitest':
         specifier: 22.5.4
-        version: 22.5.4(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(typescript@5.9.3)(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.0.9)
+        version: 22.5.4(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(typescript@5.9.3)(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0))(vitest@4.0.9)
       '@nx/web':
         specifier: 22.5.4
         version: 22.5.4(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))
@@ -83,10 +83,10 @@ importers:
         version: 1.139.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tanstack/react-router-devtools':
         specifier: ^1.139.3
-        version: 1.139.3(@tanstack/react-router@1.139.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@tanstack/router-core@1.139.3)(@types/node@20.19.9)(csstype@3.1.3)(jiti@2.4.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.10)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+        version: 1.139.3(@tanstack/react-router@1.139.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@tanstack/router-core@1.139.3)(@types/node@20.19.9)(csstype@3.1.3)(jiti@2.4.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.10)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)
       '@tanstack/router-plugin':
         specifier: ^1.139.3
-        version: 1.139.3(@tanstack/react-router@1.139.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.102.0(@swc/core@1.15.8(@swc/helpers@0.5.19))(esbuild@0.19.12))
+        version: 1.139.3(@tanstack/react-router@1.139.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.102.0(@swc/core@1.15.8(@swc/helpers@0.5.19))(esbuild@0.19.12))
       '@tanstack/zod-adapter':
         specifier: ^1.139.3
         version: 1.139.3(@tanstack/react-router@1.139.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(zod@3.25.76)
@@ -110,7 +110,7 @@ importers:
         version: 19.0.0
       '@vitejs/plugin-react':
         specifier: ^4.2.0
-        version: 4.7.0(vite@7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))
+        version: 4.7.0(vite@7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0))
       '@vitest/coverage-v8':
         specifier: 4.0.9
         version: 4.0.9(vitest@4.0.9)
@@ -188,37 +188,37 @@ importers:
         version: 6.1.2(encoding@0.1.13)(typanion@3.14.0)
       vite:
         specifier: 7.1.8
-        version: 7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+        version: 7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)
       vite-plugin-dts:
         specifier: ~4.5.0
-        version: 4.5.4(@types/node@20.19.9)(rollup@4.52.3)(typescript@5.9.3)(vite@7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))
+        version: 4.5.4(@types/node@20.19.9)(rollup@4.52.3)(typescript@5.9.3)(vite@7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0))
       vitest:
         specifier: 4.0.9
-        version: 4.0.9(@types/node@20.19.9)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@22.1.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+        version: 4.0.9(@types/node@20.19.9)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@22.1.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)
 
   example/app:
     dependencies:
       '@effect/platform-browser':
-        specifier: ^4.0.0-beta.43
-        version: 4.0.0-beta.46(effect@4.0.0-beta.46)
+        specifier: ^4.0.0-beta.70
+        version: 4.0.0-beta.70(effect@4.0.0-beta.70)
       '@nx/react':
         specifier: 22.4.5
-        version: 22.4.5(@babel/core@7.28.0)(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/helpers@0.5.19)(@types/babel__core@7.20.5)(@zkochan/js-yaml@0.0.7)(esbuild@0.19.12)(eslint@9.28.0(jiti@2.4.2))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.0.9)
+        version: 22.4.5(@babel/core@7.28.0)(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/helpers@0.5.19)(@types/babel__core@7.20.5)(@zkochan/js-yaml@0.0.7)(esbuild@0.19.12)(eslint@9.28.0(jiti@2.4.2))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0))(vitest@4.0.9)
       '@nx/vite':
         specifier: 22.5.4
-        version: 22.5.4(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(typescript@5.9.3)(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.0.9)
+        version: 22.5.4(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(typescript@5.9.3)(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0))(vitest@4.0.9)
       '@tanstack/react-router':
         specifier: ^1.139.3
         version: 1.139.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tanstack/react-router-devtools':
         specifier: ^1.139.3
-        version: 1.139.3(@tanstack/react-router@1.139.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@tanstack/router-core@1.139.3)(@types/node@22.17.0)(csstype@3.1.3)(jiti@2.4.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.10)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+        version: 1.139.3(@tanstack/react-router@1.139.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@tanstack/router-core@1.139.3)(@types/node@22.17.0)(csstype@3.1.3)(jiti@2.4.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.10)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)
       '@tanstack/router-plugin':
         specifier: ^1.139.3
-        version: 1.139.3(@tanstack/react-router@1.139.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.102.0(@swc/core@1.15.8(@swc/helpers@0.5.19))(esbuild@0.19.12))
+        version: 1.139.3(@tanstack/react-router@1.139.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.102.0(@swc/core@1.15.8(@swc/helpers@0.5.19))(esbuild@0.19.12))
       '@vitejs/plugin-react':
         specifier: ^4.2.0
-        version: 4.7.0(vite@7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))
+        version: 4.7.0(vite@7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -226,8 +226,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       effect:
-        specifier: ^4.0.0-beta.43
-        version: 4.0.0-beta.46
+        specifier: ^4.0.0-beta.70
+        version: 4.0.0-beta.70
       firebase:
         specifier: ^12.8.0
         version: 12.8.0
@@ -242,7 +242,7 @@ importers:
         version: 3.4.0
       vite:
         specifier: 7.1.8
-        version: 7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+        version: 7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)
     devDependencies:
       '@effect-firebase/client':
         specifier: workspace:*
@@ -266,8 +266,8 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0
       effect:
-        specifier: ^4.0.0-beta.43
-        version: 4.0.0-beta.46
+        specifier: ^4.0.0-beta.70
+        version: 4.0.0-beta.70
       firebase-admin:
         specifier: ^13.6.0
         version: 13.6.0(encoding@0.1.13)
@@ -275,8 +275,8 @@ importers:
   example/shared:
     dependencies:
       effect:
-        specifier: ^4.0.0-beta.43
-        version: 4.0.0-beta.46
+        specifier: ^4.0.0-beta.70
+        version: 4.0.0-beta.70
       tslib:
         specifier: ^2.3.0
         version: 2.8.1
@@ -292,8 +292,8 @@ importers:
         version: 2.8.1
     devDependencies:
       effect:
-        specifier: ^4.0.0-beta.43
-        version: 4.0.0-beta.46
+        specifier: ^4.0.0-beta.70
+        version: 4.0.0-beta.70
       effect-firebase:
         specifier: workspace:*
         version: link:../effect-firebase
@@ -317,8 +317,8 @@ importers:
         version: 2.8.1
     devDependencies:
       effect:
-        specifier: ^4.0.0-beta.43
-        version: 4.0.0-beta.46
+        specifier: ^4.0.0-beta.70
+        version: 4.0.0-beta.70
       effect-firebase:
         specifier: workspace:*
         version: link:../effect-firebase
@@ -333,8 +333,8 @@ importers:
         version: 2.8.1
     devDependencies:
       effect:
-        specifier: ^4.0.0-beta.43
-        version: 4.0.0-beta.46
+        specifier: ^4.0.0-beta.70
+        version: 4.0.0-beta.70
 
   packages/mock:
     dependencies:
@@ -343,8 +343,8 @@ importers:
         version: 2.8.1
     devDependencies:
       effect:
-        specifier: ^4.0.0-beta.43
-        version: 4.0.0-beta.46
+        specifier: ^4.0.0-beta.70
+        version: 4.0.0-beta.70
       effect-firebase:
         specifier: workspace:*
         version: link:../effect-firebase
@@ -996,15 +996,15 @@ packages:
   '@dabh/diagnostics@2.0.3':
     resolution: {integrity: sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==}
 
-  '@effect/platform-browser@4.0.0-beta.46':
-    resolution: {integrity: sha512-839fY7BwU+CsxGu8t5ynZDpT2PdGUo0bIoRiHEeDTiOYQ9bmzBK71Lw3PRTWnBbWRkCccLks7xmbkvzzkUHCIA==}
+  '@effect/platform-browser@4.0.0-beta.70':
+    resolution: {integrity: sha512-m5MYc2DY6TC+LkgaGnAwn7M2Xr1hDYgN1lrhl2braitd0LlqYG8SrjaraJJC5KcPXavr0BSWdrwaDwiNA1CEQA==}
     peerDependencies:
-      effect: ^4.0.0-beta.46
+      effect: ^4.0.0-beta.70
 
-  '@effect/vitest@4.0.0-beta.46':
-    resolution: {integrity: sha512-D3KJxcBZhdL/5Ivtt0/Vy+6UDFQs7b6wnt9/uX4IUeEJ38WzvOQ0HQqXgm8yEABIqZQa3gp6ukZ1O4XY+3hQug==}
+  '@effect/vitest@4.0.0-beta.70':
+    resolution: {integrity: sha512-XDteNN0xfOgoMauAVoN5iylxVgEjp7kFsGFq18tZ5XYjek0eOZa0nOoes5s7Bs71VvwjnCeCbFMD7IhxswEt8A==}
     peerDependencies:
-      effect: ^4.0.0-beta.46
+      effect: ^4.0.0-beta.70
       vitest: ^3.0.0 || ^4.0.0
 
   '@electric-sql/pglite-tools@0.2.11':
@@ -3033,9 +3033,6 @@ packages:
     resolution: {integrity: sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==}
     engines: {node: '>=14.16'}
 
-  '@standard-schema/spec@1.0.0':
-    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
-
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -4935,8 +4932,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  effect@4.0.0-beta.46:
-    resolution: {integrity: sha512-3f6gXvvUMtEueCRY0tU76Vq2Pej1SAwwE+s0Owd5nD53yS5n4RZhUA1rlCGFuSbQFA225pGy8vO72+lpvu7u5A==}
+  effect@4.0.0-beta.70:
+    resolution: {integrity: sha512-8AwGTRiNriirHGEYHrOS0E9fzdhIqCdZjiHP1YXmNo2UyPGS43ILsymsSHT7V0DJS+8dvlKq2RxnrDBUhDNZHg==}
 
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
@@ -5295,8 +5292,8 @@ packages:
     resolution: {integrity: sha512-6ypT4XfgqJk/F3Yuv4SX26I3doUjt0GTG4a+JgWxXQpxXzTBq8fPUeGHfcYMMDPHJHm3yPOSjaeBwBGAHWXCdA==}
     engines: {node: '>=18.0.0'}
 
-  fast-check@4.6.0:
-    resolution: {integrity: sha512-h7H6Dm0Fy+H4ciQYFxFjXnXkzR2kr9Fb22c0UBpHnm59K2zpr2t13aPTHlltFiNT6zuxp6HMPAVVvgur4BLdpA==}
+  fast-check@4.8.0:
+    resolution: {integrity: sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==}
     engines: {node: '>=12.17.0'}
 
   fast-deep-equal@3.1.3:
@@ -5993,9 +5990,9 @@ packages:
     resolution: {integrity: sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==}
     engines: {node: '>=10'}
 
-  ini@6.0.0:
-    resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+  ini@7.0.0:
+    resolution: {integrity: sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   inspect-with-kind@1.0.5:
     resolution: {integrity: sha512-MAQUJuIo7Xqk8EVNP+6d3CKq9c80hi4tjIbIAT6lmGW9W6WzlHiu9PS8uSuUYU+Do+j1baiFp3H25XEVxDIG2g==}
@@ -6891,8 +6888,8 @@ packages:
     resolution: {integrity: sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==}
     hasBin: true
 
-  msgpackr@1.11.9:
-    resolution: {integrity: sha512-FkoAAyyA6HM8wL882EcEyFZ9s7hVADSwG9xrVx3dxxNQAtgADTrJoEWivID82Iv1zWDsv/OtbrrcZAzGzOMdNw==}
+  msgpackr@2.0.1:
+    resolution: {integrity: sha512-9J+tqTEsbHqY8YohazYgty7LgerFIWxvMLpUjqETSmjHojtJm2WnX2kK/2a1fLI7CO7ERP1YSEUXMucz4j+yBA==}
 
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
@@ -8419,8 +8416,9 @@ packages:
     resolution: {integrity: sha512-MD9MjpVNhVyH4fyd5rKphjvt/1qj+PtQUz65aFqAZA6XniWAuSFRjLk3e2VALEFlh9OwBpXUN7rfeqSnT/Fmkw==}
     engines: {node: '>=14.16'}
 
-  toml@3.0.0:
-    resolution: {integrity: sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==}
+  toml@4.1.1:
+    resolution: {integrity: sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==}
+    engines: {node: '>=20'}
 
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
@@ -8696,8 +8694,8 @@ packages:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
     hasBin: true
 
-  uuid@13.0.0:
-    resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   uuid@8.3.2:
@@ -8706,6 +8704,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -9036,6 +9035,11 @@ packages:
 
   yaml@2.8.3:
     resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
@@ -9933,15 +9937,15 @@ snapshots:
       enabled: 2.0.0
       kuler: 2.0.0
 
-  '@effect/platform-browser@4.0.0-beta.46(effect@4.0.0-beta.46)':
+  '@effect/platform-browser@4.0.0-beta.70(effect@4.0.0-beta.70)':
     dependencies:
-      effect: 4.0.0-beta.46
+      effect: 4.0.0-beta.70
       multipasta: 0.2.7
 
-  '@effect/vitest@4.0.0-beta.46(effect@4.0.0-beta.46)(vitest@4.0.9)':
+  '@effect/vitest@4.0.0-beta.70(effect@4.0.0-beta.70)(vitest@4.0.9)':
     dependencies:
-      effect: 4.0.0-beta.46
-      vitest: 4.0.9(@types/node@20.19.9)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@22.1.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+      effect: 4.0.0-beta.70
+      vitest: 4.0.9(@types/node@20.19.9)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@22.1.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)
 
   '@electric-sql/pglite-tools@0.2.11(@electric-sql/pglite@0.3.6)':
     dependencies:
@@ -12094,7 +12098,7 @@ snapshots:
   '@nx/nx-win32-x64-msvc@22.5.4':
     optional: true
 
-  '@nx/react@22.4.5(@babel/core@7.28.0)(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/helpers@0.5.19)(@types/babel__core@7.20.5)(@zkochan/js-yaml@0.0.7)(esbuild@0.19.12)(eslint@9.28.0(jiti@2.4.2))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.0.9)':
+  '@nx/react@22.4.5(@babel/core@7.28.0)(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/helpers@0.5.19)(@types/babel__core@7.20.5)(@zkochan/js-yaml@0.0.7)(esbuild@0.19.12)(eslint@9.28.0(jiti@2.4.2))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0))(vitest@4.0.9)':
     dependencies:
       '@nx/devkit': 22.4.5(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))
       '@nx/eslint': 22.4.5(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(@zkochan/js-yaml@0.0.7)(eslint@9.28.0(jiti@2.4.2))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))
@@ -12111,7 +12115,7 @@ snapshots:
       semver: 7.7.2
       tslib: 2.8.1
     optionalDependencies:
-      '@nx/vite': 22.4.5(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(typescript@5.9.3)(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.0.9)
+      '@nx/vite': 22.4.5(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(typescript@5.9.3)(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0))(vitest@4.0.9)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/traverse'
@@ -12138,7 +12142,7 @@ snapshots:
       - vue-tsc
       - webpack-cli
 
-  '@nx/react@22.5.4(@babel/core@7.28.0)(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/helpers@0.5.19)(@types/babel__core@7.20.5)(@zkochan/js-yaml@0.0.7)(esbuild@0.19.12)(eslint@9.28.0(jiti@2.4.2))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.0.9)':
+  '@nx/react@22.5.4(@babel/core@7.28.0)(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/helpers@0.5.19)(@types/babel__core@7.20.5)(@zkochan/js-yaml@0.0.7)(esbuild@0.19.12)(eslint@9.28.0(jiti@2.4.2))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0))(vitest@4.0.9)':
     dependencies:
       '@nx/devkit': 22.5.4(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))
       '@nx/eslint': 22.5.4(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(@zkochan/js-yaml@0.0.7)(eslint@9.28.0(jiti@2.4.2))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))
@@ -12155,7 +12159,7 @@ snapshots:
       semver: 7.7.2
       tslib: 2.8.1
     optionalDependencies:
-      '@nx/vite': 22.5.4(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(typescript@5.9.3)(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.0.9)
+      '@nx/vite': 22.5.4(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(typescript@5.9.3)(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0))(vitest@4.0.9)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/traverse'
@@ -12244,11 +12248,11 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/vite@22.4.5(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(typescript@5.9.3)(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.0.9)':
+  '@nx/vite@22.4.5(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(typescript@5.9.3)(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0))(vitest@4.0.9)':
     dependencies:
       '@nx/devkit': 22.4.5(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))
       '@nx/js': 22.4.5(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/vitest': 22.4.5(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(typescript@5.9.3)(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.0.9)
+      '@nx/vitest': 22.4.5(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(typescript@5.9.3)(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0))(vitest@4.0.9)
       '@phenomnomnominal/tsquery': 6.1.4(typescript@5.9.3)
       ajv: 8.17.1
       enquirer: 2.3.6
@@ -12256,8 +12260,8 @@ snapshots:
       semver: 7.7.2
       tsconfig-paths: 4.2.0
       tslib: 2.8.1
-      vite: 7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
-      vitest: 4.0.9(@types/node@22.17.0)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@22.1.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)
+      vitest: 4.0.9(@types/node@22.17.0)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@22.1.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -12269,11 +12273,11 @@ snapshots:
       - verdaccio
     optional: true
 
-  '@nx/vite@22.5.4(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(typescript@5.9.3)(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.0.9)':
+  '@nx/vite@22.5.4(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(typescript@5.9.3)(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0))(vitest@4.0.9)':
     dependencies:
       '@nx/devkit': 22.5.4(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))
       '@nx/js': 22.5.4(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/vitest': 22.5.4(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(typescript@5.9.3)(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.0.9)
+      '@nx/vitest': 22.5.4(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(typescript@5.9.3)(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0))(vitest@4.0.9)
       '@phenomnomnominal/tsquery': 6.1.4(typescript@5.9.3)
       ajv: 8.17.1
       enquirer: 2.3.6
@@ -12281,8 +12285,8 @@ snapshots:
       semver: 7.7.2
       tsconfig-paths: 4.2.0
       tslib: 2.8.1
-      vite: 7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
-      vitest: 4.0.9(@types/node@20.19.9)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@22.1.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)
+      vitest: 4.0.9(@types/node@20.19.9)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@22.1.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -12293,11 +12297,11 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/vite@22.5.4(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(typescript@5.9.3)(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.0.9)':
+  '@nx/vite@22.5.4(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(typescript@5.9.3)(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0))(vitest@4.0.9)':
     dependencies:
       '@nx/devkit': 22.5.4(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))
       '@nx/js': 22.5.4(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/vitest': 22.5.4(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(typescript@5.9.3)(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.0.9)
+      '@nx/vitest': 22.5.4(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(typescript@5.9.3)(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0))(vitest@4.0.9)
       '@phenomnomnominal/tsquery': 6.1.4(typescript@5.9.3)
       ajv: 8.17.1
       enquirer: 2.3.6
@@ -12305,8 +12309,8 @@ snapshots:
       semver: 7.7.2
       tsconfig-paths: 4.2.0
       tslib: 2.8.1
-      vite: 7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
-      vitest: 4.0.9(@types/node@22.17.0)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@22.1.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)
+      vitest: 4.0.9(@types/node@22.17.0)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@22.1.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -12317,7 +12321,7 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/vitest@22.4.5(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(typescript@5.9.3)(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.0.9)':
+  '@nx/vitest@22.4.5(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(typescript@5.9.3)(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0))(vitest@4.0.9)':
     dependencies:
       '@nx/devkit': 22.4.5(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))
       '@nx/js': 22.4.5(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))
@@ -12325,8 +12329,8 @@ snapshots:
       semver: 7.7.2
       tslib: 2.8.1
     optionalDependencies:
-      vite: 7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
-      vitest: 4.0.9(@types/node@22.17.0)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@22.1.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)
+      vitest: 4.0.9(@types/node@22.17.0)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@22.1.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -12338,7 +12342,7 @@ snapshots:
       - verdaccio
     optional: true
 
-  '@nx/vitest@22.5.4(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(typescript@5.9.3)(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.0.9)':
+  '@nx/vitest@22.5.4(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(typescript@5.9.3)(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0))(vitest@4.0.9)':
     dependencies:
       '@nx/devkit': 22.5.4(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))
       '@nx/js': 22.5.4(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))
@@ -12346,8 +12350,8 @@ snapshots:
       semver: 7.7.2
       tslib: 2.8.1
     optionalDependencies:
-      vite: 7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
-      vitest: 4.0.9(@types/node@20.19.9)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@22.1.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)
+      vitest: 4.0.9(@types/node@20.19.9)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@22.1.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -12358,7 +12362,7 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/vitest@22.5.4(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(typescript@5.9.3)(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.0.9)':
+  '@nx/vitest@22.5.4(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(typescript@5.9.3)(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))(vite@7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0))(vitest@4.0.9)':
     dependencies:
       '@nx/devkit': 22.5.4(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))
       '@nx/js': 22.5.4(@babel/traverse@7.28.0)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19))(nx@22.5.4(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.19)))(verdaccio@6.1.2(encoding@0.1.13)(typanion@3.14.0))
@@ -12366,8 +12370,8 @@ snapshots:
       semver: 7.7.2
       tslib: 2.8.1
     optionalDependencies:
-      vite: 7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
-      vitest: 4.0.9(@types/node@22.17.0)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@22.1.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)
+      vitest: 4.0.9(@types/node@22.17.0)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@22.1.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -12795,8 +12799,6 @@ snapshots:
 
   '@sindresorhus/is@5.6.0': {}
 
-  '@standard-schema/spec@1.0.0': {}
-
   '@standard-schema/spec@1.1.0': {}
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.28.0)':
@@ -13003,13 +13005,13 @@ snapshots:
 
   '@tanstack/history@1.139.0': {}
 
-  '@tanstack/react-router-devtools@1.139.3(@tanstack/react-router@1.139.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@tanstack/router-core@1.139.3)(@types/node@20.19.9)(csstype@3.1.3)(jiti@2.4.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.10)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)':
+  '@tanstack/react-router-devtools@1.139.3(@tanstack/react-router@1.139.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@tanstack/router-core@1.139.3)(@types/node@20.19.9)(csstype@3.1.3)(jiti@2.4.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.10)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)':
     dependencies:
       '@tanstack/react-router': 1.139.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@tanstack/router-devtools-core': 1.139.3(@tanstack/router-core@1.139.3)(@types/node@20.19.9)(csstype@3.1.3)(jiti@2.4.2)(solid-js@1.9.10)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+      '@tanstack/router-devtools-core': 1.139.3(@tanstack/router-core@1.139.3)(@types/node@20.19.9)(csstype@3.1.3)(jiti@2.4.2)(solid-js@1.9.10)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      vite: 7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)
     optionalDependencies:
       '@tanstack/router-core': 1.139.3
     transitivePeerDependencies:
@@ -13027,13 +13029,13 @@ snapshots:
       - tsx
       - yaml
 
-  '@tanstack/react-router-devtools@1.139.3(@tanstack/react-router@1.139.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@tanstack/router-core@1.139.3)(@types/node@22.17.0)(csstype@3.1.3)(jiti@2.4.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.10)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)':
+  '@tanstack/react-router-devtools@1.139.3(@tanstack/react-router@1.139.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@tanstack/router-core@1.139.3)(@types/node@22.17.0)(csstype@3.1.3)(jiti@2.4.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.10)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)':
     dependencies:
       '@tanstack/react-router': 1.139.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@tanstack/router-devtools-core': 1.139.3(@tanstack/router-core@1.139.3)(@types/node@22.17.0)(csstype@3.1.3)(jiti@2.4.2)(solid-js@1.9.10)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+      '@tanstack/router-devtools-core': 1.139.3(@tanstack/router-core@1.139.3)(@types/node@22.17.0)(csstype@3.1.3)(jiti@2.4.2)(solid-js@1.9.10)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      vite: 7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)
     optionalDependencies:
       '@tanstack/router-core': 1.139.3
     transitivePeerDependencies:
@@ -13079,14 +13081,14 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  '@tanstack/router-devtools-core@1.139.3(@tanstack/router-core@1.139.3)(@types/node@20.19.9)(csstype@3.1.3)(jiti@2.4.2)(solid-js@1.9.10)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)':
+  '@tanstack/router-devtools-core@1.139.3(@tanstack/router-core@1.139.3)(@types/node@20.19.9)(csstype@3.1.3)(jiti@2.4.2)(solid-js@1.9.10)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)':
     dependencies:
       '@tanstack/router-core': 1.139.3
       clsx: 2.1.1
       goober: 2.1.18(csstype@3.1.3)
       solid-js: 1.9.10
       tiny-invariant: 1.3.3
-      vite: 7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)
     optionalDependencies:
       csstype: 3.1.3
     transitivePeerDependencies:
@@ -13102,14 +13104,14 @@ snapshots:
       - tsx
       - yaml
 
-  '@tanstack/router-devtools-core@1.139.3(@tanstack/router-core@1.139.3)(@types/node@22.17.0)(csstype@3.1.3)(jiti@2.4.2)(solid-js@1.9.10)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)':
+  '@tanstack/router-devtools-core@1.139.3(@tanstack/router-core@1.139.3)(@types/node@22.17.0)(csstype@3.1.3)(jiti@2.4.2)(solid-js@1.9.10)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)':
     dependencies:
       '@tanstack/router-core': 1.139.3
       clsx: 2.1.1
       goober: 2.1.18(csstype@3.1.3)
       solid-js: 1.9.10
       tiny-invariant: 1.3.3
-      vite: 7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)
     optionalDependencies:
       csstype: 3.1.3
     transitivePeerDependencies:
@@ -13138,7 +13140,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.139.3(@tanstack/react-router@1.139.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.102.0(@swc/core@1.15.8(@swc/helpers@0.5.19))(esbuild@0.19.12))':
+  '@tanstack/router-plugin@1.139.3(@tanstack/react-router@1.139.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.102.0(@swc/core@1.15.8(@swc/helpers@0.5.19))(esbuild@0.19.12))':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.0)
@@ -13156,12 +13158,12 @@ snapshots:
       zod: 3.25.76
     optionalDependencies:
       '@tanstack/react-router': 1.139.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      vite: 7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)
       webpack: 5.102.0(@swc/core@1.15.8(@swc/helpers@0.5.19))(esbuild@0.19.12)
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.139.3(@tanstack/react-router@1.139.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.102.0(@swc/core@1.15.8(@swc/helpers@0.5.19))(esbuild@0.19.12))':
+  '@tanstack/router-plugin@1.139.3(@tanstack/react-router@1.139.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.102.0(@swc/core@1.15.8(@swc/helpers@0.5.19))(esbuild@0.19.12))':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.0)
@@ -13179,7 +13181,7 @@ snapshots:
       zod: 3.25.76
     optionalDependencies:
       '@tanstack/react-router': 1.139.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      vite: 7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)
       webpack: 5.102.0(@swc/core@1.15.8(@swc/helpers@0.5.19))(esbuild@0.19.12)
     transitivePeerDependencies:
       - supports-color
@@ -13674,7 +13676,7 @@ snapshots:
       minimatch: 7.4.6
       semver: 7.7.1
 
-  '@vitejs/plugin-react@4.7.0(vite@7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))':
+  '@vitejs/plugin-react@4.7.0(vite@7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.0)
@@ -13682,11 +13684,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.7.0(vite@7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))':
+  '@vitejs/plugin-react@4.7.0(vite@7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.0)
@@ -13694,7 +13696,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -13711,34 +13713,34 @@ snapshots:
       magicast: 0.5.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.9(@types/node@20.19.9)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@22.1.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+      vitest: 4.0.9(@types/node@20.19.9)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@22.1.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
   '@vitest/expect@4.0.9':
     dependencies:
-      '@standard-schema/spec': 1.0.0
+      '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
       '@vitest/spy': 4.0.9
       '@vitest/utils': 4.0.9
       chai: 6.2.1
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.9(vite@7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))':
+  '@vitest/mocker@4.0.9(vite@7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.0.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)
 
-  '@vitest/mocker@4.0.9(vite@7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))':
+  '@vitest/mocker@4.0.9(vite@7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.0.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.0.9':
     dependencies:
@@ -13766,7 +13768,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.0.9(@types/node@22.17.0)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@22.1.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+      vitest: 4.0.9(@types/node@22.17.0)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@22.1.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)
 
   '@vitest/utils@4.0.9':
     dependencies:
@@ -15141,18 +15143,18 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  effect@4.0.0-beta.46:
+  effect@4.0.0-beta.70:
     dependencies:
       '@standard-schema/spec': 1.1.0
-      fast-check: 4.6.0
+      fast-check: 4.8.0
       find-my-way-ts: 0.1.6
-      ini: 6.0.0
+      ini: 7.0.0
       kubernetes-types: 1.30.0
-      msgpackr: 1.11.9
+      msgpackr: 2.0.1
       multipasta: 0.2.7
-      toml: 3.0.0
-      uuid: 13.0.0
-      yaml: 2.8.3
+      toml: 4.1.1
+      uuid: 14.0.0
+      yaml: 2.9.0
 
   ejs@3.1.10:
     dependencies:
@@ -15760,7 +15762,7 @@ snapshots:
 
   farmhash-modern@1.1.0: {}
 
-  fast-check@4.6.0:
+  fast-check@4.8.0:
     dependencies:
       pure-rand: 8.4.0
 
@@ -16830,7 +16832,7 @@ snapshots:
 
   ini@2.0.0: {}
 
-  ini@6.0.0: {}
+  ini@7.0.0: {}
 
   inspect-with-kind@1.0.5:
     dependencies:
@@ -17741,7 +17743,7 @@ snapshots:
       '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.3
     optional: true
 
-  msgpackr@1.11.9:
+  msgpackr@2.0.1:
     optionalDependencies:
       msgpackr-extract: 3.0.3
 
@@ -17927,7 +17929,7 @@ snapshots:
       tree-kill: 1.2.2
       tsconfig-paths: 4.2.0
       tslib: 2.8.1
-      yaml: 2.8.0
+      yaml: 2.8.3
       yargs: 17.7.2
       yargs-parser: 21.1.1
     optionalDependencies:
@@ -18082,7 +18084,7 @@ snapshots:
 
   openapi3-ts@3.2.0:
     dependencies:
-      yaml: 2.8.0
+      yaml: 2.8.3
 
   opener@1.5.2: {}
 
@@ -18388,7 +18390,7 @@ snapshots:
   postcss-load-config@4.0.2(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@types/node@20.19.9)(typescript@5.9.3)):
     dependencies:
       lilconfig: 3.1.3
-      yaml: 2.8.0
+      yaml: 2.8.3
     optionalDependencies:
       postcss: 8.4.38
       ts-node: 10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.19))(@types/node@20.19.9)(typescript@5.9.3)
@@ -19613,7 +19615,7 @@ snapshots:
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
 
-  toml@3.0.0: {}
+  toml@4.1.1: {}
 
   totalist@3.0.1: {}
 
@@ -19911,7 +19913,7 @@ snapshots:
 
   uuid@11.1.0: {}
 
-  uuid@13.0.0: {}
+  uuid@14.0.0: {}
 
   uuid@8.3.2: {}
 
@@ -20001,7 +20003,7 @@ snapshots:
       core-util-is: 1.0.2
       extsprintf: 1.3.0
 
-  vite-plugin-dts@4.5.4(@types/node@20.19.9)(rollup@4.52.3)(typescript@5.9.3)(vite@7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)):
+  vite-plugin-dts@4.5.4(@types/node@20.19.9)(rollup@4.52.3)(typescript@5.9.3)(vite@7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)):
     dependencies:
       '@microsoft/api-extractor': 7.52.9(@types/node@20.19.9)
       '@rollup/pluginutils': 5.2.0(rollup@4.52.3)
@@ -20014,13 +20016,13 @@ snapshots:
       magic-string: 0.30.17
       typescript: 5.9.3
     optionalDependencies:
-      vite: 7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  vite@7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3):
+  vite@7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.5
       fdir: 6.5.0(picomatch@4.0.3)
@@ -20034,9 +20036,9 @@ snapshots:
       jiti: 2.4.2
       terser: 5.43.1
       tsx: 4.20.6
-      yaml: 2.8.3
+      yaml: 2.9.0
 
-  vite@7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3):
+  vite@7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.5
       fdir: 6.5.0(picomatch@4.0.3)
@@ -20050,12 +20052,12 @@ snapshots:
       jiti: 2.4.2
       terser: 5.43.1
       tsx: 4.20.6
-      yaml: 2.8.3
+      yaml: 2.9.0
 
-  vitest@4.0.9(@types/node@20.19.9)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@22.1.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3):
+  vitest@4.0.9(@types/node@20.19.9)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@22.1.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0):
     dependencies:
       '@vitest/expect': 4.0.9
-      '@vitest/mocker': 4.0.9(vite@7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))
+      '@vitest/mocker': 4.0.9(vite@7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0))
       '@vitest/pretty-format': 4.0.9
       '@vitest/runner': 4.0.9
       '@vitest/snapshot': 4.0.9
@@ -20072,7 +20074,7 @@ snapshots:
       tinyexec: 0.3.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.1.8(@types/node@20.19.9)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.9
@@ -20092,10 +20094,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.0.9(@types/node@22.17.0)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@22.1.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3):
+  vitest@4.0.9(@types/node@22.17.0)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@22.1.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0):
     dependencies:
       '@vitest/expect': 4.0.9
-      '@vitest/mocker': 4.0.9(vite@7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))
+      '@vitest/mocker': 4.0.9(vite@7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0))
       '@vitest/pretty-format': 4.0.9
       '@vitest/runner': 4.0.9
       '@vitest/snapshot': 4.0.9
@@ -20112,7 +20114,7 @@ snapshots:
       tinyexec: 0.3.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.1.8(@types/node@22.17.0)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.17.0
@@ -20357,6 +20359,8 @@ snapshots:
   yaml@2.8.0: {}
 
   yaml@2.8.3: {}
+
+  yaml@2.9.0: {}
 
   yargs-parser@20.2.9: {}
 


### PR DESCRIPTION
## Summary
This PR upgrades the Effect library dependency from beta.43 to beta.70 across all packages and updates the codebase to use the renamed `Model.GeneratedByDb` API that reflects the new behavior in Effect beta.70.

## Key Changes

- **Dependency Upgrade**: Updated `effect` and related packages (`@effect/platform-browser`, `@effect/vitest`) from `^4.0.0-beta.43` to `^4.0.0-beta.70` across all package.json files
- **API Migration**: Renamed all occurrences of `Model.Generated` to `Model.GeneratedByDb` to match the new Effect API naming
- **Behavior Update**: Updated documentation and tests to reflect that `GeneratedByDb` fields are now excluded from both `add` and `update` operations (previously required in `update`)
- **Repository Type Constraint**: Removed `keyof S['update']['Type']` constraint from the `Repository` type definition, as generated fields are no longer part of the update schema
- **Test Updates**: Removed `id` field assignments from update/encode test cases where they were previously required
- **Documentation**: Updated README.md, MIGRATION.md, and inline documentation to reflect the new `GeneratedByDb` naming and behavior
- **Code Cleanup**: Removed duplicate `deleteRecursive` method definition in MockFirestoreService

## Notable Implementation Details

The change from `Model.Generated` to `Model.GeneratedByDb` is more than a rename—it represents a semantic shift in how generated fields are handled. These fields are now completely excluded from update operations, which simplifies the type system and removes the need for the `keyof S['update']['Type']` constraint in the Repository type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Effect and related dependencies to v4.0.0-beta.70 across all packages.

* **Documentation**
  * Updated migration guides and code examples to reflect changes in database-generated field configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fwal/effect-firebase/pull/31?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->