### PR TITLE
ci: use Nx Cloud only on main, run PRs locally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,6 @@ jobs:
   main:
     name: Main
     runs-on: ubuntu-latest
-    env:
-      # GitHub does not expose repository secrets to workflows triggered by
-      # PRs from forks, so NX_CLOUD_ACCESS_TOKEN is empty for contributor PRs.
-      # Detect those runs and fall back to running Nx locally (no cloud), which
-      # keeps CI green without leaking the token to untrusted fork code.
-      IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -37,8 +31,9 @@ jobs:
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
-      # Skipped for fork PRs, which have no access to the Nx Cloud token.
-      - if: ${{ env.IS_FORK_PR == 'false' }}
+      # Only runs on pushes to main. PRs (including forks, which have no access
+      # to the Nx Cloud token) run Nx locally, so distribution is skipped.
+      - if: ${{ github.event_name == 'push' }}
         run: pnpm dlx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
       # Cache node_modules
@@ -55,6 +50,6 @@ jobs:
       # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
       - run: pnpm exec nx affected -t lint test build
         env:
-          # Fork PRs run without Nx Cloud (no token); disable it entirely so Nx
-          # runs tasks locally on the runner instead of attempting to connect.
-          NX_NO_CLOUD: ${{ env.IS_FORK_PR }}
+          # PRs run without Nx Cloud so they don't depend on the access token
+          # (unavailable to forks). Only pushes to main use the remote cache.
+          NX_NO_CLOUD: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,12 @@ jobs:
   main:
     name: Main
     runs-on: ubuntu-latest
+    env:
+      # GitHub does not expose repository secrets to workflows triggered by
+      # PRs from forks, so NX_CLOUD_ACCESS_TOKEN is empty for contributor PRs.
+      # Detect those runs and fall back to running Nx locally (no cloud), which
+      # keeps CI green without leaking the token to untrusted fork code.
+      IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -31,8 +37,9 @@ jobs:
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
-      # Uncomment this line to enable task distribution
-      - run: pnpm dlx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+      # Skipped for fork PRs, which have no access to the Nx Cloud token.
+      - if: ${{ env.IS_FORK_PR == 'false' }}
+        run: pnpm dlx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
       # Cache node_modules
       - uses: actions/setup-node@v4
@@ -47,3 +54,7 @@ jobs:
       # - run: pnpm exec nx-cloud record -- echo Hello World
       # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
       - run: pnpm exec nx affected -t lint test build
+        env:
+          # Fork PRs run without Nx Cloud (no token); disable it entirely so Nx
+          # runs tasks locally on the runner instead of attempting to connect.
+          NX_NO_CLOUD: ${{ env.IS_FORK_PR }}


### PR DESCRIPTION
## Problem

PRs from external contributors fail CI because GitHub does not expose repository secrets to workflows triggered by PRs from forks. As a result `NX_CLOUD_ACCESS_TOKEN` is empty on those runs, and the `nx-cloud start-ci-run` distribution step fails when it tries to authenticate.

## Change

Stop depending on the Nx Cloud access token for pull requests. Nx Cloud (task distribution + remote cache writes) now runs **only on pushes to `main`**; **all** pull requests — from this repo or a fork — run `nx affected` locally.

| Trigger | Distribution (`start-ci-run`) | Cache reads | Cache writes |
|---|---|---|---|
| Push to `main` | ✅ | ✅ | ✅ |
| Any PR (own or fork) | ❌ skipped | ❌ (`NX_NO_CLOUD`) | ❌ |

Concretely:
- The `start-ci-run` step is gated on `github.event_name == 'push'` (only `main`, per the workflow triggers).
- The `nx affected` step sets `NX_NO_CLOUD` for `pull_request` events, so PRs run tasks on the runner and never reference the token.

## Why this approach

- No fork special-casing and no token exposed on any PR run — contributor PRs pass.
- The remote cache is still populated on every merge to `main`, so local dev machines and `main` CI keep benefiting from it.
- Avoids `pull_request_target`, which would run untrusted fork code with a write-capable `GITHUB_TOKEN` in scope.

Trade-off: PR CI runs cold (no remote-cache reads). Negligible at this repo's size; can be revisited later by embedding a read-only token for cache reads if PR times grow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKPMobWjRwcz9TDzS3Kryp

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKPMobWjRwcz9TDzS3Kryp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request validation by running Nx tasks locally when cloud access is unavailable.
  * Restricted distributed task execution to push-based workflows, increasing CI reliability for pull requests and forks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->